### PR TITLE
Align documentation ports with screenshots (8888 → 8000)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ SPOTIFY_CLIENT_SECRET=
 # Redirect URI used for the OAuth flow.
 # It must exactly match one of the Redirect URIs set in your Spotify Developer app settings.
 # Recommended default for local scripts:
-SPOTIFY_REDIRECT_URI=http://127.0.0.1:8888/callback
+SPOTIFY_REDIRECT_URI=http://127.0.0.1:8000/callback
 
 # -----------------------------------------------------------------------------
 # OPTIONAL CONFIGURATION

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
     - `SPOTIFY_CLIENT_ID`
     - `SPOTIFY_CLIENT_SECRET`
     - `SPOTIFY_REDIRECT_URI` (must match exactly with what is set in your Spotify app settings,
-      e.g. <http://127.0.0.1:8888/callback>)
+      e.g. <http://127.0.0.1:8000/callback>)
 
    **Optional:**
 

--- a/docs/en/SPOTIFY_DEVELOPER_SETUP.md
+++ b/docs/en/SPOTIFY_DEVELOPER_SETUP.md
@@ -56,7 +56,7 @@ Copy both values to your `.env` file.
 ### 5. Configure Redirect URI
 
 1. In your app dashboard, click **“Edit Settings”**.
-2. Under **Redirect URIs**, add: <http://127.0.0.1:8888/callback> *(or the exact Redirect URI you will use in your .env
+2. Under **Redirect URIs**, add: <http://127.0.0.1:8000/callback> *(or the exact Redirect URI you will use in your .env
    configuration)*
 3. Click **Save**.
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -72,7 +72,7 @@ pip install -r requirements.txt
     - `SPOTIFY_CLIENT_ID`
     - `SPOTIFY_CLIENT_SECRET`
     - `SPOTIFY_REDIRECT_URI` (debe coincidir exactamente con la configuración de tu app en Spotify, por
-      ejemplo <http://127.0.0.1:8888/callback>)
+      ejemplo <http://127.0.0.1:8000/callback>)
 
    Variables opcionales:
 

--- a/docs/es/SPOTIFY_DEVELOPER_SETUP.md
+++ b/docs/es/SPOTIFY_DEVELOPER_SETUP.md
@@ -56,7 +56,7 @@ Copia ambos valores y añádelos a tu archivo `.env`.
 ### 5. Configura tu Redirect URI
 
 1. En el panel de tu app, haz clic en **“Edit Settings”**.
-2. Bajo **Redirect URIs**, añade: <http://127.0.0.1:8888/callback> *(o el Redirect URI exacto que usarás en tu
+2. Bajo **Redirect URIs**, añade: <http://127.0.0.1:8000/callback> *(o el Redirect URI exacto que usarás en tu
    configuración `.env`)*.
 3. Haz clic en **Save**.
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
     - `SPOTIFY_CLIENT_ID`
     - `SPOTIFY_CLIENT_SECRET`
     - `SPOTIFY_REDIRECT_URI` (doit correspondre exactement à ce qui est configuré dans votre application Spotify,
-      ex. <http://127.0.0.1:8888/callback>)
+      ex. <http://127.0.0.1:8000/callback>)
 
    Variables optionnelles:
 

--- a/docs/fr/SPOTIFY_DEVELOPER_SETUP.md
+++ b/docs/fr/SPOTIFY_DEVELOPER_SETUP.md
@@ -56,7 +56,7 @@ Copiez ces deux valeurs et ajoutez-les à votre fichier `.env`.
 ### 5. Configurez votre Redirect URI
 
 1. Dans le tableau de bord de votre application, cliquez sur **“Edit Settings”**.
-2. Sous **Redirect URIs**, ajoutez : <http://127.0.0.1:8888/callback> *(ou l'URI exact configuré dans votre `.env`)*.
+2. Sous **Redirect URIs**, ajoutez : <http://127.0.0.1:8000/callback> *(ou l'URI exact configuré dans votre `.env`)*.
 3. Cliquez sur **Save**.
 
 ![Configuration des Redirect URIs](../images/redirect-uris-capture.png)

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -70,7 +70,7 @@ pip install -r requirements.txt
     - `SPOTIFY_CLIENT_ID`
     - `SPOTIFY_CLIENT_SECRET`
     - `SPOTIFY_REDIRECT_URI` (deve corrispondere esattamente a quanto configurato nella tua app Spotify,
-      es. <http://127.0.0.1:8888/callback>)
+      es. <http://127.0.0.1:8000/callback>)
 
    Variabili opzionali:
 

--- a/docs/it/SPOTIFY_DEVELOPER_SETUP.md
+++ b/docs/it/SPOTIFY_DEVELOPER_SETUP.md
@@ -56,7 +56,7 @@ Copia entrambi i valori e aggiungili al tuo file `.env`.
 ### 5. Configura il Redirect URI
 
 1. Nel pannello della tua app, clicca su **“Edit Settings”**.
-2. Sotto **Redirect URIs**, aggiungi: <http://127.0.0.1:8888/callback> *(o l'URI esatto configurato nel tuo `.env`)*.
+2. Sotto **Redirect URIs**, aggiungi: <http://127.0.0.1:8000/callback> *(o l'URI esatto configurato nel tuo `.env`)*.
 3. Clicca su **Save**.
 
 ![Configurazione Redirect URIs](../images/redirect-uris-capture.png)

--- a/docs/pt/README.md
+++ b/docs/pt/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
     - `SPOTIFY_CLIENT_ID`
     - `SPOTIFY_CLIENT_SECRET`
     - `SPOTIFY_REDIRECT_URI` (deve ser exatamente igual ao configurado no seu app Spotify,
-      ex. <http://127.0.0.1:8888/callback>)
+      ex. <http://127.0.0.1:8000/callback>)
 
    Variáveis opcionais:
 

--- a/docs/pt/SPOTIFY_DEVELOPER_SETUP.md
+++ b/docs/pt/SPOTIFY_DEVELOPER_SETUP.md
@@ -56,7 +56,7 @@ Copie ambos e adicione ao seu arquivo `.env`.
 ### 5. Configure seu Redirect URI
 
 1. No painel do app, clique em **“Edit Settings”**.
-2. Em **Redirect URIs**, adicione: <http://127.0.0.1:8888/callback> *(ou o Redirect URI exato configurado no seu `.env`)*.
+2. Em **Redirect URIs**, adicione: <http://127.0.0.1:8000/callback> *(ou o Redirect URI exato configurado no seu `.env`)*.
 3. Clique em **Save**.
 
 ![Configuração de Redirect URIs](../images/redirect-uris-capture.png)


### PR DESCRIPTION
Updated the documentation to use port 8000 instead of 8888, so it matches the ports shown in the screenshots. This ensures consistency between the written instructions and the provided visuals.